### PR TITLE
[tech] Add Rails::Gate.configure method

### DIFF
--- a/lib/gate/rails.rb
+++ b/lib/gate/rails.rb
@@ -10,6 +10,11 @@ module Gate
       base.send(:extend, ClassMethods)
     end
 
+    def self.configure(&block)
+      dynamic_class = "BaseSchema"
+      Object.const_set(dynamic_class, Class.new(Dry::Validation::Schema, &block))
+    end
+
     module ClassMethods
       def params_schemas
         @params_schemas ||= {}
@@ -22,7 +27,7 @@ module Gate
       end
 
       def def_schema(&block)
-        @_schema = Dry::Validation.Params(&block)
+        @_schema = Dry::Validation.Params(BaseSchema, &block)
       end
 
       def method_added(method_name)

--- a/test/dummy/app/controllers/invalid_controller.rb
+++ b/test/dummy/app/controllers/invalid_controller.rb
@@ -6,7 +6,7 @@ class InvalidController < ApplicationController
   }
 
   def_schema do
-    required(:foo).filled
+    required(:foo).filled(:foo?)
   end
 
   def with_custom_invalid

--- a/test/dummy/config/initializers/gate.rb
+++ b/test/dummy/config/initializers/gate.rb
@@ -1,0 +1,9 @@
+Gate::Rails.configure do
+  configure do |config|
+    config.messages_file = Rails.root.join("fixtures", "en.yml")
+
+    def foo?(value)
+      value == "FOO"
+    end
+  end
+end

--- a/test/dummy/fixtures/en.yml
+++ b/test/dummy/fixtures/en.yml
@@ -1,0 +1,3 @@
+en:
+  errors:
+    foo?: "it's not a foo!"

--- a/test/gate/test_rails.rb
+++ b/test/gate/test_rails.rb
@@ -35,7 +35,14 @@ module Gate
       get "/with_custom_invalid", params: { "bar" => "BAR" }
 
       assert_response :bad_request
-      assert_equal @response.body, { foo: ["is missing"] }.inspect
+      assert_equal @response.body, { foo: ["is missing", "it's not a foo!"] }.inspect
+    end
+
+    def test_base_configuration
+      get "/with_custom_invalid", params: { "foo" => "FOO1" }
+
+      assert_response :bad_request
+      assert_equal @response.body, { foo: ["it's not a foo!"]  }.inspect
     end
   end
 end


### PR DESCRIPTION
**Solution for #12** 

Hi ya @jandudulski!
I finished my proposition of feature request related to inheriting the base configuration. It's really simple but I have a few doubts about the interface of `#configure` method. It's really annoying that there is repeating `configure` keyword but I wanted to stay consistent with dry-rb way. What do you think about it? 

```ruby
Gate::Rails.configure do
  configure do |config|
    config.messages_file = Rails.root.join("fixtures", "en.yml")

     def foo?(value)
      value == "FOO"
    end
  end
end
```