### PR TITLE
[#12] Provide possibility of implementing base, centralized configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,50 @@ class ExampleController < ActionController::Base
 end
 ```
 
+## Configuration
+
+Gate gives a possibility to create global, inherited configuration and separated setup in each one schema definition.
+
+### Inheriting base setup
+
+In order to configure the library according to the whole application, create a file under `config/initializers/gate.rb`. There is a possibility of creating a base configuration, defining shared, custom predicates and a lot more useful things. The full list of supported configuration options is consistent with available options in [dry-validation](https://dry-rb.org/gems/dry-validation/) gem.
+
+```ruby
+Gate::Rails.configure do
+  configure do |config|
+    config.messages_file = Rails.root.join("config", "locales" "en.yml")
+
+    predicates(SharedPredicates)
+
+    def foo?(value)
+      value == "FOO"
+    end
+  end
+end
+```
+
+### Separated setup
+
+Sometimes there is a requirement to have a very specific configuration or behaviour in a one schema validation. The easiest way is to do it in a special `configure` block.
+
+```ruby
+class DoSomethingCommand
+  include Gate::Command
+
+  schema do
+    configure do
+      config.messages_file = Rails.root.join("config", "locales" "special_en.yml")
+      predicates(SharedPredicates)
+    end
+    required(:id).filled
+    required(:message).schema do
+      required(:title).filled
+      optional(:value).maybe(:decimal?)
+    end
+  end
+end
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/gate/rails.rb
+++ b/lib/gate/rails.rb
@@ -5,9 +5,14 @@ module Gate
     attr_reader :validated_params
 
     SchemaNotDefined = Class.new(StandardError)
+    @base_schema = nil
 
     def self.included(base)
       base.send(:extend, ClassMethods)
+    end
+
+    def self.configure(&block)
+      @base_schema = Class.new(Dry::Validation::Schema, &block)
     end
 
     module ClassMethods
@@ -22,7 +27,7 @@ module Gate
       end
 
       def def_schema(&block)
-        @_schema = Dry::Validation.Params(&block)
+        @_schema = Dry::Validation.Params(Gate::Rails::instance_variable_get(:@base_schema), &block)
       end
 
       def method_added(method_name)

--- a/test/dummy/app/controllers/invalid_controller.rb
+++ b/test/dummy/app/controllers/invalid_controller.rb
@@ -6,7 +6,7 @@ class InvalidController < ApplicationController
   }
 
   def_schema do
-    required(:foo).filled
+    required(:foo).filled(:foo?)
   end
 
   def with_custom_invalid

--- a/test/dummy/config/initializers/gate.rb
+++ b/test/dummy/config/initializers/gate.rb
@@ -1,0 +1,9 @@
+Gate::Rails.configure do
+  configure do |config|
+    config.messages_file = Rails.root.join("fixtures", "en.yml")
+
+    def foo?(value)
+      value == "FOO"
+    end
+  end
+end

--- a/test/dummy/fixtures/en.yml
+++ b/test/dummy/fixtures/en.yml
@@ -1,0 +1,3 @@
+en:
+  errors:
+    foo?: "it's not a foo!"

--- a/test/gate/test_rails.rb
+++ b/test/gate/test_rails.rb
@@ -35,7 +35,14 @@ module Gate
       get "/with_custom_invalid", params: { "bar" => "BAR" }
 
       assert_response :bad_request
-      assert_equal @response.body, { foo: ["is missing"] }.inspect
+      assert_equal @response.body, { foo: ["is missing", "it's not a foo!"] }.inspect
+    end
+
+    def test_base_configuration
+      get "/with_custom_invalid", params: { "foo" => "FOO1" }
+
+      assert_response :bad_request
+      assert_equal @response.body, { foo: ["it's not a foo!"]  }.inspect
     end
   end
 end


### PR DESCRIPTION
**Solution for #12** 

Hi ya @jandudulski!
I finished my proposition of feature request related to inheriting the base configuration. It's really simple but I have a few doubts about the interface of `#configure` method. It's really annoying that there is repeating `configure` keyword but I wanted to stay consistent with dry-rb way. What do you think about it? 

```ruby
Gate::Rails.configure do
  configure do |config|
    config.messages_file = Rails.root.join("fixtures", "en.yml")

     def foo?(value)
      value == "FOO"
    end
  end
end
```